### PR TITLE
Couchbase 2.0.1

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -16,5 +16,6 @@ MANIFEST			This list of files
 META.yml
 README.md
 t/00-load.t
+t/couchbase.t
 t/manifest.t
 t/pod.t

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -7,9 +7,10 @@ license  'perl';
 
 build_requires 'Test::More';
 requires 'Catalyst::Plugin::Session' => 0.27;
-requires 'Couchbase::Client' => 1.00;
+requires 'Couchbase';
 requires 'Moose';
 requires 'Catalyst::ClassData';
+requires 'URI::Escape';
 
 auto_install;
 

--- a/lib/Catalyst/Plugin/Session/Store/Couchbase.pm
+++ b/lib/Catalyst/Plugin/Session/Store/Couchbase.pm
@@ -4,13 +4,15 @@ use MRO::Compat;
 extends 'Catalyst::Plugin::Session::Store';
 with 'Catalyst::ClassData';
 use Catalyst::Exception;
-use Couchbase::Client 1.00;
+use Couchbase::Bucket;
+use Couchbase::Document;
 use namespace::clean -except => 'meta'; # The last bit cargo culted.
 use Storable qw(nfreeze thaw);
+use URI::Escape qw(uri_escape);
 
-our $VERSION = '0.93';
+our $VERSION = '0.94';
 
-__PACKAGE__->mk_classdata('_session_couchbase_handle');
+__PACKAGE__->mk_classdata('_session_cb_bucket_handle');
 __PACKAGE__->mk_classdata('_session_couchbase_prefix');
 
 =head1 NAME
@@ -26,11 +28,48 @@ Catalyst::Plugin::Session::Store::Couchbase
     },
     Couchbase => {
       server => 'couchbase01.domain',
-      username => 'Administrator',
       password => 'password',
       bucket => 'default',
+      ssl => 1,
+      certpath => '/example/certpath/cert.pem',
     }
   );
+
+=head1 CONFIG OPTIONS
+
+=over 4
+
+=item server
+
+The Couchbase server to connect to. If there are multiple nodes in a cluster,
+multiple servers can be provided as a comma-delimited list (ex: host1,host2),
+which can improve reliability if the primary connection node is down. If the
+cluster is responding on a different port, it may be provided as host:port,
+where port is the memcached listening port.
+
+=item password
+
+Password for the given bucket. This can be omitted if a password is not set on
+the given bucket.
+
+=item bucket
+
+Bucket name to connect to. Defaults to "default" if it is not provided.
+
+=item ssl
+
+Set to 1 if the cluster is SSL-enabled and a SSL connection is desired. SSL
+support requires Couchbase Server 2.5 or higher and a copy of the server's
+SSL certificate. Defaults to off.
+
+=item certpath
+
+Path to the server's SSL pem-encoded certificate for validation. Not required if
+SSL is disabled.
+
+=item timeout
+
+Timeout (in seconds) to allow for bootstrapping a client. Defaults to 6.
 
 =cut
 
@@ -45,40 +84,31 @@ sub setup_session {
     my $appname = "$c";
     $c->_session_couchbase_prefix($appname . "sess:");
 
-    my $cb = Couchbase::Client->new({
-        server => $cfg->{server},
-        username => $cfg->{username},
-        password => $cfg->{password},
-        bucket => $cfg->{bucket},
-        compress_threshold => 25_000,
-        timeout => 6.0,
-    });
-    Catalyst::Exception->throw("Couchbase client undefined!")
-        unless defined $cb;
+    my $connection_url = _build_couchbase_url($cfg);
+    my $bucket = Couchbase::Bucket->new($connection_url);
+    Catalyst::Exception->throw("Couchbase bucket object undefined!")
+        unless defined $bucket;
 
-    if (my @errs = @{$cb->get_errors}) {
-        Catalyst::Exception->throw(
-            "Couchbase client errors:\n"
-             . join("\n", map { $_->[1] } @errs)
-         );
-    }
-    $c->_session_couchbase_handle($cb);
-    1;
+    $c->_session_cb_bucket_handle($bucket);
+
+    return 1;
 }
 
 sub get_session_data {
     my ($c, $key) = @_;
     croak("No cache key specified") unless length($key);
+
     $key = $c->_session_couchbase_prefix . $key;
-    my $r = $c->_session_couchbase_handle->get($key);
-    if (defined $r and defined $r->value) {
-        return $r->value;
+    my $doc = Couchbase::Document->new($key);
+    $c->_session_cb_bucket_handle->get_and_touch($doc);
+    if (defined $doc and $doc->is_ok and defined $doc->value) {
+        return $doc->value;
     }
-    elsif (defined $r) {
-        my $err = $r->errstr;
+    elsif (defined $doc) {
+        my $err = $doc->errstr;
         Catalyst::Exception->throw(
             "Failed to fetch Couchbase item: $err. Key was: $key"
-        ) unless $err =~ /No such key/;
+        ) unless $err =~ /key does not exist/;
     }
     return;
 }
@@ -86,19 +116,22 @@ sub get_session_data {
 sub store_session_data {
     my ($c, $key, $data) = @_;
     croak("No cache key specified") unless length($key);
+
     $key = $c->_session_couchbase_prefix . $key;
     my $expiry = $c->session_expires ? $c->session_expires - time() : 0;
     if (not $expiry) {
         $c->log->warn("No expiry set for sessions! Defaulting to one hour..");
         $expiry = 3600;
     }
-    my $r = $c->_session_couchbase_handle->set(
-        $key => $data,
-        int($expiry) # required due to outstanding bug in XS client code
+    my $doc = Couchbase::Document->new(
+        $key,
+        $data,
+        { expiry => int($expiry) }
     );
-    unless (defined $r and $r->is_ok) {
+    $c->_session_cb_bucket_handle->upsert($doc);
+    unless ($doc->is_ok) {
         Catalyst::Exception->throw(
-            "Couldn't save $key / $data in couchbase storage: " . $r->errstr
+            "Couldn't save $key / $data in couchbase storage: " . $doc->errstr
         );
     }
     return 1;
@@ -108,15 +141,53 @@ sub delete_session_data {
     my ($c, $key) = @_;
     $c->log->debug("Couchbase session store: delete_session_data($key)") if $c->debug;
     croak("No cache key specified") unless length($key);
+
     $key = $c->_session_couchbase_prefix . $key;
-    $c->_session_couchbase_handle->remove($key);
-    # Couchbase::Client API doesn't current specify what return codes apply to
-    # this operation, so ignore 'em..
-    return;
+
+    my $doc = Couchbase::Document->new($key);
+    $c->_session_cb_bucket_handle->remove($doc);
+    return ( $doc->is_ok );
 }
 
 # Not required as Couchbase expires things itself.
 sub delete_expired_sessions { }
+
+# Build a Couchbase connection string
+sub _build_couchbase_url {
+    my ($cfg) = @_;
+
+    # Set timeout to 6 seconds
+    my %options = (
+        config_node_timeout => ( $cfg->{timeout} or 6 ) * 1_000_000,
+    );
+
+    # Connection URL is couchbases?://host1,host2/bucket?options
+    my $connection_url = join('/',
+        ':/',
+        $cfg->{server},
+        ( $cfg->{bucket} or 'default' ),
+    );
+
+    $options{password} = $cfg->{password} if ($cfg->{password});
+
+    if ($cfg->{ssl}) {
+        if (not $cfg->{certpath} or not -e $cfg->{certpath}) {
+            Catalyst::Exception->throw(
+                'SSL enabled, but certpath is missing or invalid'
+            );
+        }
+        $connection_url = 'couchbases' . $connection_url;
+        $options{certpath} = $cfg->{certpath};
+    } else {
+        $connection_url = 'couchbase' . $connection_url;
+    }
+
+    $connection_url .= '?' . join(
+        '&', ( map { $_ . '=' . uri_escape($options{$_}) } keys %options )
+    );
+
+    return $connection_url;
+}
 
 =head1 AUTHOR
 

--- a/t/couchbase.t
+++ b/t/couchbase.t
@@ -6,9 +6,6 @@ use Test::More tests => 8;
 
 use_ok('Catalyst::Plugin::Session::Store::Couchbase');
 
-my $uri = ( $ENV{'COUCHBASE_TEST_HOST'} or 'localhost' );
-my $db = ( $ENV{'COUCHBASE_TEST_BUCKET'} or 'app_session' );
-
 ok(
 	my $s = Catalyst::Plugin::Session::Store::Couchbase->new(),
 	'new'
@@ -63,10 +60,6 @@ sub test__build_couchbase_url {
 		(not $response),
 		'_build_couchbase_url - ssl without certpath - empty response'
 	);
-}
-
-if ( $ENV{'COUCHBASE_LIVE_TEST'} ) {
-
 }
 
 done_testing();

--- a/t/couchbase.t
+++ b/t/couchbase.t
@@ -1,0 +1,74 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+use Test::More tests => 8;
+
+use_ok('Catalyst::Plugin::Session::Store::Couchbase');
+
+my $uri = ( $ENV{'COUCHBASE_TEST_HOST'} or 'localhost' );
+my $db = ( $ENV{'COUCHBASE_TEST_BUCKET'} or 'app_session' );
+
+ok(
+	my $s = Catalyst::Plugin::Session::Store::Couchbase->new(),
+	'new'
+);
+
+test__build_couchbase_url();
+
+sub test__build_couchbase_url {
+	my $response = Catalyst::Plugin::Session::Store::Couchbase::_build_couchbase_url({
+		server => 'localhost',
+	});
+	like(
+		$response,
+		qr/^couchbase:\/\/localhost\/default\?/,
+		'_build_couchbase_url - host and defaults - pre-query url'
+	);
+	like(
+		$response,
+		qr/config_node_timeout=6/,
+		'_build_couchbase_url - host and defaults - config_node_timeout'
+	);
+	$response = Catalyst::Plugin::Session::Store::Couchbase::_build_couchbase_url({
+		server => 'localhost',
+		timeout => 20,
+	});
+	like(
+		$response,
+		qr/config_node_timeout=20/,
+		'_build_couchbase_url - host and timeout - config_node_timeout'
+	);
+	$response = Catalyst::Plugin::Session::Store::Couchbase::_build_couchbase_url({
+		server => 'host1,host2,host3',
+		bucket => 'different'
+	});
+	like(
+		$response,
+		qr/^couchbase:\/\/host1,host2,host3\/different\?/,
+		'_build_couchbase_url - multihost and bucket - pre-query url'
+	);
+	$response = eval {
+		Catalyst::Plugin::Session::Store::Couchbase::_build_couchbase_url({
+			server => 'localhost',
+			ssl => 1,
+		});
+	};
+	like(
+		$@,
+		qr/SSL enabled, but certpath is missing or invalid/,
+		'_build_couchbase_url - ssl without certpath - throws exception'
+	);
+	ok(
+		(not $response),
+		'_build_couchbase_url - ssl without certpath - empty response'
+	);
+}
+
+if ( $ENV{'COUCHBASE_LIVE_TEST'} ) {
+
+}
+
+done_testing();
+
+1;

--- a/t/pod.t
+++ b/t/pod.t
@@ -4,6 +4,10 @@ use strict;
 use warnings;
 use Test::More;
 
+unless ( $ENV{RELEASE_TESTING} ) {
+    plan( skip_all => "Author tests not required for installation" );
+}
+
 # Ensure a recent version of Test::Pod
 my $min_tp = 1.22;
 eval "use Test::Pod $min_tp";


### PR DESCRIPTION
Hello!

This is one of two optional pull requests, and if neither will work, I can publish separately. This branch moves your module to the 'Couchbase' module on CPAN, which replaces the deprecated Couchbase::Client. Furthermore, it moves the session store types (session/expires/flash) into one document to save on key space. I have another branch available that is just the Couchbase migration without the merging into one document, if that seems needlessly complex for your module, and I can create a pull request with that one instead.

The additional unit test only covers the connection url builder.

Comments and questions are welcome.
